### PR TITLE
Move `const` after the type for consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ Constants should be camel-case with all words capitalized and prefixed by the re
 **Preferred:**
 
 ```objc
-static const NSTimeInterval RWTutorialViewControllerNavigationFadeAnimationDuration = 0.3;
+static NSTimeInterval const RWTutorialViewControllerNavigationFadeAnimationDuration = 0.3;
 ```
 
 **Not Preferred:**
 
 ```objc
-static const NSTimeInterval fadetime = 1.7;
+static NSTimeInterval const fadetime = 1.7;
 ```
 
 Properties should be camel-case with the leading word being lowercase. Use auto-synthesis for properties rather than manual @synthesize statements unless you have good reason.
@@ -344,9 +344,9 @@ Constants are preferred over in-line string literals or numbers, as they allow f
 **Preferred:**
 
 ```objc
-static const NSString *RWAboutViewControllerCompanyName = @"RayWenderlich.com";
+static NSString * const RWAboutViewControllerCompanyName = @"RayWenderlich.com";
 
-static const CGFloat RWImageThumbnailHeight = 50.0;
+static CGFloat const RWImageThumbnailHeight = 50.0;
 ```
 
 **Not Preferred:**


### PR DESCRIPTION
For pointers to things like NSString, the `const` needs to be after the `*`. Reading the declaration from right to left, `static const NSString *foo` means "foo is a pointer to an NSString that is constant". i.e. the NSString data is constant, but NSStrings are already immutable. That means the pointer `foo` can be reassigned to some other string.

What we want is `static NSString * const foo` which means "foo is a constant, unchangeable pointer to an NSString".

This next point is debatable, but for consistency, I suggest always putting the `const` after the type for primitive types too. Technically, `const` is supposed to modify what precedes it.

Reference: http://stackoverflow.com/questions/7526152/easy-rule-to-read-complicated-const-declarations
