### PR TITLE
Naming Category Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here are some of the documents from Apple that informed the style guide. If some
 * [Class Constructor Methods](#class-constructor-methods)
 * [CGRect Functions](#cgrect-functions)
 * [Golden Path](#golden-path)
+* [Image Naming](#image-naming)
 * [Error handling](#error-handling)
 * [Singletons](#singletons)
 * [Line Breaks](#line-breaks)
@@ -649,6 +650,14 @@ When coding with conditionals, the left hand margin of the code should be the "g
   }
 }
 ```
+## Image Naming
+
+Image names should be named consistently to preserve organization and developer sanity. They should be named as one camel case string with a description of their purpose, followed by the un-prefixed name of the class or property they are customizing (if there is one), followed by a further description of color and/or placement, and finally their state.
+
+For example:
+
+`RefreshBarButtonItem` / `RefreshBarButtonItem@2x` and `RefreshBarButtonItemSelected` / `RefreshBarButtonItemSelected@2x`
+`ArticleNavigationBarWhite` / `ArticleNavigationBarWhite@2x` and `ArticleNavigationBarBlackSelected` / `ArticleNavigationBarBlackSelected@2x`.
 
 ## Error handling
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The official raywenderlich.com Objective-C style guide.
+﻿# The official raywenderlich.com Objective-C style guide.
 
 This style guide outlines the coding conventions for raywenderlich.com.
 
@@ -31,6 +31,7 @@ Here are some of the documents from Apple that informed the style guide. If some
 * [Comments](#comments)
 * [Naming](#naming)
   * [Underscores](#underscores)
+* [Creating Header Files] (#creating-header-files)
 * [Methods](#methods)
 * [Variables](#variables)
 * [Property Attributes](#property-attributes)
@@ -227,6 +228,23 @@ When using properties, instance variables should always be accessed and mutated 
 An exception to this: inside initializers, the backing instance variable (i.e. _variableName) should be used directly to avoid any potential side effects of the getters/setters.
 
 Local variables should not contain underscores.
+
+## Creating Header Files
+
+Always have the following code in the header file, so that header files in import does not get repeated.
+
+For Example: creating a class named BaseViewController
+
+```objc
+#ifndef BASE_VIEW_CONTROLLER
+#define BASE_VIEW_CONTROLLER
+
+//Interface and Declaration goes here...
+
+#endif
+```
+
+This is because if the file has been expanded already, it will not expand it again!
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Here are some of the documents from Apple that informed the style guide. If some
 * [Comments](#comments)
 * [Naming](#naming)
   * [Underscores](#underscores)
-* [Creating Header Files] (#creating-header-files)
 * [Methods](#methods)
 * [Variables](#variables)
 * [Property Attributes](#property-attributes)
@@ -42,13 +41,13 @@ Here are some of the documents from Apple that informed the style guide. If some
 * [Case Statements](#case-statements)
 * [Private Properties](#private-properties)
 * [Booleans](#booleans)
+* [Categry Method Naming](#category-method-naming)
 * [Conditionals](#conditionals)
   * [Ternary Operator](#ternary-operator)
 * [Init Methods](#init-methods)
 * [Class Constructor Methods](#class-constructor-methods)
 * [CGRect Functions](#cgrect-functions)
 * [Golden Path](#golden-path)
-* [Image Naming](#image-naming)
 * [Error handling](#error-handling)
 * [Singletons](#singletons)
 * [Line Breaks](#line-breaks)
@@ -229,23 +228,6 @@ When using properties, instance variables should always be accessed and mutated 
 An exception to this: inside initializers, the backing instance variable (i.e. _variableName) should be used directly to avoid any potential side effects of the getters/setters.
 
 Local variables should not contain underscores.
-
-## Creating Header Files
-
-Always have the following code in the header file, so that header files in import does not get repeated.
-
-For Example: creating a class named BaseViewController
-
-```objc
-#ifndef BASE_VIEW_CONTROLLER
-#define BASE_VIEW_CONTROLLER
-
-//Interface and Declaration goes here...
-
-#endif
-```
-
-This is because if the file has been expanded already, it will not expand it again!
 
 ## Methods
 
@@ -524,6 +506,24 @@ If the name of a `BOOL` property is expressed as an adjective, the property can 
 ```
 Text and example taken from the [Cocoa Naming Guidelines](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-BAJGIIJE).
 
+## Category Method Naming
+
+All category methods must have a prefix. This is to avoid conflicts when a method in two or more categories has the same signature.
+
+**Preferred:**
+
+```objc
+@interface UIButton (HVDAdditions)
++ (UIButton *)HVD_bigRedButton;
+```
+
+**Not Preferred:**
+
+```objc
+@interface UIButton (HVDAdditions)
++ (UIButton *)bigRedButton;
+```
+
 ## Conditionals
 
 Conditional bodies should always use braces even when a conditional body could be written without braces (e.g., it is one line only) to prevent errors. These errors include adding a second line and expecting it to be part of the if-statement. Another, [even more dangerous defect](http://programmers.stackexchange.com/a/16530) may happen where the line "inside" the if-statement is commented out, and the next line unwittingly becomes part of the if-statement. In addition, this style is more consistent with all other conditionals, and therefore more easily scannable.
@@ -650,14 +650,6 @@ When coding with conditionals, the left hand margin of the code should be the "g
   }
 }
 ```
-## Image Naming
-
-Image names should be named consistently to preserve organization and developer sanity. They should be named as one camel case string with a description of their purpose, followed by the un-prefixed name of the class or property they are customizing (if there is one), followed by a further description of color and/or placement, and finally their state.
-
-For example:
-
-`RefreshBarButtonItem` / `RefreshBarButtonItem@2x` and `RefreshBarButtonItemSelected` / `RefreshBarButtonItemSelected@2x`
-`ArticleNavigationBarWhite` / `ArticleNavigationBarWhite@2x` and `ArticleNavigationBarBlackSelected` / `ArticleNavigationBarBlackSelected@2x`.
 
 ## Error handling
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here are some of the documents from Apple that informed the style guide. If some
 * [Case Statements](#case-statements)
 * [Private Properties](#private-properties)
 * [Booleans](#booleans)
-* [Categry Method Naming](#category-method-naming)
+* [Category Method Naming](#category-method-naming)
 * [Conditionals](#conditionals)
   * [Ternary Operator](#ternary-operator)
 * [Init Methods](#init-methods)


### PR DESCRIPTION
Naming methods in categories to avoid clashes with method names in the same class or method names in a different category in the same class or superclass.

Source: https://developer.apple.com/library/ios/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html
