### PR TITLE
Fixed logical error in section Booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ This allows for more consistency across files and greater visual clarity.
 **Preferred:**
 
 ```objc
-if (someObject) {}
+if (!someObject) {}
 if (![anotherObject boolValue]) {}
 ```
 


### PR DESCRIPTION
If I'm not totally mistaken, the the equivalent short check is `if(!someObject)` when you check for `someObject == nil`  
