### PR TITLE
"count" is a property, not a method

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,14 +322,14 @@ Dot-notation should **always** be used for accessing and mutating properties, as
 
 **Preferred:**
 ```objc
-NSInteger arrayCount = [self.array count];
+NSInteger arrayCount = self.array.count;
 view.backgroundColor = [UIColor orangeColor];
 [UIApplication sharedApplication].delegate;
 ```
 
 **Not Preferred:**
 ```objc
-NSInteger arrayCount = self.array.count;
+NSInteger arrayCount = [self.array count];
 [view setBackgroundColor:[UIColor orangeColor]];
 UIApplication.sharedApplication.delegate;
 ```


### PR DESCRIPTION
I'm not sure if `count` was a property when this style guide was written, but it is in current iOS SDK. I think this needs to be updated.
